### PR TITLE
Added TrustingKeyStore

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ Start hacking
     import io.shaka.http.Https.TrustAllSslCertificates
     TrustAllSslCertificates
     ...
+    //Trust all SSL certificates (non-globally)
+    import io.shaka.http.Https.TrustingKeyStore
+    implicit val https = Some(TrustingKeyStore("TLS"))
+    val response = http(GET("https://someurl"))
+    ...
     //Use a key store
     import io.shaka.http.Https.HttpsKeyStore
     implicit val https = Some(HttpsKeyStore("src/test/resources/certs/keystore-testing.jks", "password"))

--- a/src/main/scala/io/shaka/http/Http.scala
+++ b/src/main/scala/io/shaka/http/Http.scala
@@ -1,6 +1,6 @@
 package io.shaka.http
 
-import io.shaka.http.Https.HttpsKeyStore
+import io.shaka.http.Https.KeyStore
 import io.shaka.http.proxy._
 
 object Http {
@@ -9,7 +9,7 @@ object Http {
   type Header = (HttpHeader, String)
   val infiniteTimeout = Timeout(0)
 
-  def http(request: Request)(implicit proxy: Proxy = noProxy, keyStore: Option[HttpsKeyStore] = None, timeout: Timeout = infiniteTimeout ): Response = new ClientHttpHandler(proxy, keyStore, timeout: Timeout).apply(request)
+  def http(request: Request)(implicit proxy: Proxy = noProxy, keyStore: Option[KeyStore] = None, timeout: Timeout = infiniteTimeout ): Response = new ClientHttpHandler(proxy, keyStore, timeout: Timeout).apply(request)
 
   case class Timeout(millis: Int)
 }

--- a/src/main/scala/io/shaka/http/Https.scala
+++ b/src/main/scala/io/shaka/http/Https.scala
@@ -1,26 +1,38 @@
 package io.shaka.http
 
 import java.io.FileInputStream
-import java.security.KeyStore
+import java.security.{KeyStore ⇒ JKeyStore}
 import java.security.cert.X509Certificate
 import javax.net.ssl._
 
 object Https {
 
-  case class HttpsKeyStore(path: String, password: String)
+  trait KeyStore { def protocol: String }
+  case class HttpsKeyStore(path: String, password: String, protocol: String = "TLS") extends KeyStore
+  case class TrustingKeyStore(protocol: String = "SSL") extends KeyStore
 
-  def sslFactory(httpsKeyStore: HttpsKeyStore) = {
-    val keyStoreInputStream = new FileInputStream(httpsKeyStore.path)
-    val keyStore: KeyStore = KeyStore.getInstance(KeyStore.getDefaultType)
-
-    keyStore.load(keyStoreInputStream, httpsKeyStore.password.toCharArray)
-
-    val trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm)
-    trustManagerFactory.init(keyStore)
-
-    val sslContext = SSLContext.getInstance("TLS")
-    sslContext.init(null, trustManagerFactory.getTrustManagers, null)
+  def sslFactory(keyStore: KeyStore): SSLSocketFactory = {
+    val sslContext = SSLContext.getInstance(keyStore.protocol)
+    sslContext.init(null, trustManagers(keyStore), new java.security.SecureRandom)
     sslContext.getSocketFactory
+  }
+
+  def hostNameVerifier(keyStore: KeyStore): HostnameVerifier = keyStore match {
+    case _: HttpsKeyStore ⇒ HttpsURLConnection.getDefaultHostnameVerifier
+    case _: TrustingKeyStore ⇒ TrustAllSslCertificates.allHostsValid
+  }
+
+  private def trustManagers(keyStore: KeyStore): Array[TrustManager] = keyStore match {
+    case HttpsKeyStore(path, password, _) ⇒ {
+      val keyStoreInputStream = new FileInputStream(path)
+      val keyStore: JKeyStore = JKeyStore.getInstance(JKeyStore.getDefaultType)
+      keyStore.load(keyStoreInputStream, password.toCharArray)
+
+      val trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm)
+      trustManagerFactory.init(keyStore)
+      trustManagerFactory.getTrustManagers
+    }
+    case _: TrustingKeyStore ⇒ TrustAllSslCertificates.trustAllCerts
   }
 
   object TrustAllSslCertificates {

--- a/src/test/scala/io/shaka/http/HttpsSpec.scala
+++ b/src/test/scala/io/shaka/http/HttpsSpec.scala
@@ -1,6 +1,6 @@
 package io.shaka.http
 
-import io.shaka.http.Https.{TrustAllSslCertificates, HttpsKeyStore}
+import io.shaka.http.Https.{TrustAllSslCertificates, HttpsKeyStore, TrustingKeyStore}
 import io.shaka.http.Request.GET
 import io.shaka.http.Status.OK
 import io.shaka.http.TestHttpServer.withHttpsServer
@@ -10,9 +10,19 @@ import org.scalatest.{BeforeAndAfterEach, FunSuite}
 class HttpsSpec extends FunSuite with BeforeAndAfterEach {
   var server: TestHttpServer = _
 
-  test("https works with keystore") {
+  test("https works with https keystore") {
     withHttpsServer{server =>
       implicit val https = Some(HttpsKeyStore("src/test/resources/certs/keystore-testing.jks", "password"))
+      val expected = "helloworld"
+      val response = Http.http(GET(server.toUrl(expected)))
+      assert(response.status === OK)
+      assert(response.entityAsString === expected)
+    }
+  }
+
+  test("https works with trusting keystore") {
+    withHttpsServer{server =>
+      implicit val https = Some(TrustingKeyStore("TLS"))
       val expected = "helloworld"
       val response = Http.http(GET(server.toUrl(expected)))
       assert(response.status === OK)


### PR DESCRIPTION
This provides an alternate way to TrustAllSslCertificates & that doesn't change global mutable state (for shame !)

Small breaking change: HttpsKeyStore has a new parameter: protocol, this change can be undone by fixing protocol to "TLS" for HttpsKeyStore & "SSL" for TrustingKeyStore.