### PR TITLE
Extractors for query parameters.

### DIFF
--- a/src/main/scala/io/shaka/http/QueryParameters.scala
+++ b/src/main/scala/io/shaka/http/QueryParameters.scala
@@ -1,0 +1,30 @@
+package io.shaka.http
+
+import io.shaka.http.RequestMatching.URLMatcher
+import java.net.URLDecoder.decode
+import scala.collection.{mutable ⇒ M, breakOut} // http://stackoverflow.com/questions/1715681/scala-2-8-breakout/1716558#1716558
+
+
+/**
+  * Extract query parameters out of a url & return as a Map[String, List[String]].
+  *
+  * Use this variant if you expect or care about repetition of keys, i.e. this will happen: key=value&key=value2
+  * This is dealt with by a slightly more complex return type: Map[String, List[String]] than the lossy variant.
+  */
+object QueryParameters {
+  def unapply(queryParams: String): Option[Map[String, List[String]]] = {
+    val mutableResult: M.Map[String, M.ListBuffer[String]] =
+      M.Map.empty[String, M.ListBuffer[String]].withDefault(_ => M.ListBuffer[String]())
+
+    decode(queryParams, "UTF-8").split("&").foreach {
+      case url"$key=$value" => mutableResult += ((key, mutableResult(key) += value))
+      case _                =>
+    }
+
+    val queryParamsMultiMap: Map[String, List[String]] = mutableResult.map {
+      case (key, valuesBuffer) ⇒ (key, valuesBuffer.toList)
+    }(breakOut)
+
+    Some(queryParamsMultiMap)
+  }
+}

--- a/src/test/scala/io/shaka/http/QueryParametersSpec.scala
+++ b/src/test/scala/io/shaka/http/QueryParametersSpec.scala
@@ -1,0 +1,19 @@
+package io.shaka.http
+
+import io.shaka.http.Request.GET
+import org.scalatest.FunSuite
+import io.shaka.http.RequestMatching.URLMatcher
+
+
+class QueryParametersSpec extends FunSuite {
+  test("repeating") {
+    assert(QueryParameters.unapply("") === Some(Map()))
+    assert(QueryParameters.unapply("key=value") === Some(Map("key" -> List("value"))))
+    assert(QueryParameters.unapply("key=value&key2=value2") === Some(Map("key" -> List("value"), "key2" -> List("value2"))))
+    assert(QueryParameters.unapply("key=value&key=value2") === Some(Map("key" -> List("value", "value2"))))
+
+    assert((GET("some/url?key=oldvalue&key2=value2&key=value") match {
+      case GET(url"some/url?${QueryParameters(params)}") ⇒ params
+    }) === Map("key" -> List("oldvalue", "value"), "key2" -> List("value2")))
+  }
+}


### PR DESCRIPTION
I've created five variants ! (had too much time on my hands, evidently) 

nonrepeating.lossy which can be used when there's no repetition of keys, it's lossy because if keys are repeated only the last value is returned, the result is always Some(Map[String, String])

nonrepeating.strict is like nonreapting.lossy only it returns None (i.e. doesn't match) if any keys are repeated

nonrepeating.throwing is like nonrepeating.strict but throws a tantrum if any keys are repeated

repeating which should be used when there is repetition of keys, it's non-lossy because all values are returned, the result is always Map[String, List[String]]

mixed which returns both non-repeating & repeating keys: (one Map[String, String], the other Map[String, List[String]]).

I quite understand if this is too much & can amend to just the basics. 

We use some equivalent to repeating in CB & cope with some keys not repeating by matching on List(singleValue) & matching on manyValues for those that do.